### PR TITLE
Support for multipart upload

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,27 @@
+name: Ruby Gem
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: push gem
+        uses: trocco-io/push-gem-to-gpr-action@v2
+        with:
+          language: java
+          gem-path: "./build/gems/*.gem"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
   - **https**: use https or not (boolean, default true)
   - **user**: proxy user (string, optional)
   - **password**: proxy password (string, optional)
+- **multipart_upload**: configuration to use multipart upload. (optional)
+  - **part_size**: size of each upload a part. (string, defualt: '5g')
+  - **max_threads**: maximum number of threads to upload concurrently. (int, defualt: 4)
+  - **retry_limit**: maximum number of retries for each upload a part. (int, defualt: 3)
 
 - **auth_method**: name of mechanism to authenticate requests (basic, env, instance, profile, properties, anonymous, or session. default: basic)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "signing"
     id "org.embulk.embulk-plugins" version "0.5.5"
     id "checkstyle"
+    id "com.palantir.git-version" version "3.1.0"
 }
 
 repositories {
@@ -11,7 +12,14 @@ repositories {
 }
 
 group = "org.embulk"
-version = "1.7.1-SNAPSHOT"
+version = {
+    def vd = versionDetails()
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^[0-9]+\.[0-9]+\.[0-9]+([.-][.a-zA-Z0-9-]+)?/) {
+        vd.lastTag
+    } else {
+        "0.0.0.${vd.gitHash}"
+    }
+}()
 description = "Stores files on S3."
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     }
 
     implementation "org.embulk:embulk-util-file:0.1.3"
+    implementation "org.embulk:embulk-util-retryhelper:0.9.0"
 
     // Jackson libraries are once excluded from transitive dependencies of other dependencies, and re-added explicitly here.
     // The versions 2.6.7 are exactly the same with embulk-core's dependency before v0.10.32.

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -24,6 +24,7 @@ org.embulk:embulk-spi:0.10.37=compileClasspath
 org.embulk:embulk-util-aws-credentials:0.4.1=compileClasspath,runtimeClasspath
 org.embulk:embulk-util-config:0.3.2=compileClasspath,runtimeClasspath
 org.embulk:embulk-util-file:0.1.3=compileClasspath,runtimeClasspath
+org.embulk:embulk-util-retryhelper:0.9.0=compileClasspath,runtimeClasspath
 org.msgpack:msgpack-core:0.8.11=compileClasspath
 org.slf4j:jcl-over-slf4j:1.7.12=compileClasspath,runtimeClasspath
 org.slf4j:slf4j-api:1.7.30=compileClasspath

--- a/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
@@ -16,11 +16,17 @@
 
 package org.embulk.output.s3;
 
+import java.io.File;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Locale;
@@ -31,6 +37,15 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.util.Md5Utils;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
@@ -47,6 +62,9 @@ import org.embulk.spi.FileOutput;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.TransactionalFileOutput;
 import org.embulk.util.config.TaskMapper;
+import org.embulk.util.retryhelper.RetryExecutor;
+import org.embulk.util.retryhelper.RetryGiveupException;
+import org.embulk.util.retryhelper.Retryable;
 import org.slf4j.Logger;
 
 import com.amazonaws.ClientConfiguration;
@@ -57,6 +75,11 @@ import org.embulk.util.aws.credentials.AwsCredentialsTask;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 public class S3FileOutputPlugin
         implements FileOutputPlugin
@@ -116,6 +139,10 @@ public class S3FileOutputPlugin
         @Config("region")
         @ConfigDefault("null")
         Optional<String> getRegion();
+
+        @Config("multipart_upload")
+        @ConfigDefault("null")
+        Optional<MultipartUpload> getMultipartUpload();
     }
 
     public static class S3FileOutput
@@ -128,6 +155,7 @@ public class S3FileOutputPlugin
         private final String fileNameExtension;
         private final String tempPathPrefix;
         private final Optional<CannedAccessControlList> cannedAccessControlListOptional;
+        private final MultipartUpload multipartUpload;
 
         private int taskIndex;
         private int fileIndex;
@@ -135,6 +163,7 @@ public class S3FileOutputPlugin
         private OutputStream current;
         private Path tempFilePath;
         private String tempPath = null;
+        private String multipartUploadId = null;
 
         private AmazonS3 newS3Client(final PluginTask task)
         {
@@ -264,6 +293,7 @@ public class S3FileOutputPlugin
                 this.tempPath = task.getTempPath().get();
             }
             this.cannedAccessControlListOptional = task.getCannedAccessControlList();
+            this.multipartUpload = task.getMultipartUpload().orElse(null);
         }
 
         private static Path newTempFile(String tmpDir, String prefix)
@@ -299,6 +329,148 @@ public class S3FileOutputPlugin
             return pathPrefix + sequence + fileNameExtension;
         }
 
+        private void multipartUploadOrPutFile(Path from, String key)
+        {
+            if (from == null) {
+                return;
+            }
+            if (multipartUpload != null) {
+                multipartUploadFile(from, key);
+            }
+            else {
+                putFile(from, key);
+            }
+        }
+
+        private void multipartUploadFile(Path from, String key)
+        {
+            ExecutorService executor = Executors.newFixedThreadPool(multipartUpload.maxThreads);
+            try {
+                executeMultipartUpload(from, key, executor);
+            }
+            finally {
+                abortMultipartUploadIfNecessary(key, executor);
+            }
+        }
+
+        private void executeMultipartUpload(Path from, String key, ExecutorService executor)
+        {
+            File file = from.toFile();
+            long fileSize = file.length();
+            long fileOffset = 0;
+            long partSize = multipartUpload.partSize;
+            int partNumber = 1;
+            int totalParts = (int) (fileSize / partSize) + (fileSize % partSize == 0 ? 0 : 1);
+            List<Future<PartETag>> partETags = new ArrayList<>();
+            multipartUploadId = client.initiateMultipartUpload(new InitiateMultipartUploadRequest(bucket, key)).getUploadId();
+            for (; fileOffset < fileSize; fileOffset += partSize, partNumber++) {
+                partETags.add(submitUploadPart(key, file, fileSize, fileOffset, partSize, partNumber, totalParts, executor));
+            }
+            client.completeMultipartUpload(new CompleteMultipartUploadRequest(bucket, key, multipartUploadId, collect(partETags)));
+            multipartUploadId = null; // Successfully completed
+        }
+
+        private Future<PartETag> submitUploadPart(String key, File file, long fileSize, long fileOffset, long partSize, int partNumber, int totalParts, ExecutorService executor)
+        {
+            return executor.submit(() -> new UploadPart(key, file, fileSize, fileOffset, partSize, partNumber, totalParts).runInterruptible());
+        }
+
+        private class UploadPart implements Retryable<PartETag>
+        {
+            final RetryExecutor re = RetryExecutor.builder().withRetryLimit(multipartUpload.retryLimit).build();
+            final DecimalFormat df = new DecimalFormat("#,###"); // Not thread safe
+            final String key;
+            final File file;
+            final long fileSize;
+            final long fileOffset;
+            final long partSize;
+            final int partNumber;
+            final int totalParts;
+            final boolean isLastPart;
+            final String md5Digest;
+
+            UploadPart(String key, File file, long fileSize, long fileOffset, long partSize, int partNumber, int totalParts)
+            {
+                this.key = key;
+                this.file = file;
+                this.fileSize = fileSize;
+                this.fileOffset = fileOffset;
+                this.partSize = Math.min(partSize, fileSize - fileOffset);
+                this.partNumber = partNumber;
+                this.totalParts = totalParts;
+                isLastPart = partNumber >= totalParts;
+                md5Digest = md5AsBase64(file, fileOffset, partSize);
+            }
+
+            PartETag runInterruptible() throws InterruptedException, RetryGiveupException
+            {
+                logger.info("Uploading a part {} / {}. bucket '{}', key '{}', upload id '{}'", partNumber, totalParts, bucket, key, multipartUploadId);
+                PartETag partETag = re.runInterruptible(this);
+                logger.info("Uploaded {} / {} bytes of the file. entity tag '{}'", df.format(fileOffset + partSize), df.format(fileSize), partETag.getETag());
+                return partETag;
+            }
+
+            @Override
+            public PartETag call()
+            {
+                return uploadPart(key, file, fileOffset, partSize, partNumber, isLastPart, md5Digest);
+            }
+
+            @Override
+            public boolean isRetryableException(Exception exception)
+            {
+                return exception instanceof AmazonS3Exception;
+            }
+
+            @Override
+            public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+            {
+                logger.info("An error occurred while uploading a part {} / {}, will retry {} / {} after {} milliseconds.", partNumber, totalParts, retryCount, retryLimit, df.format(retryWait), exception);
+            }
+
+            @Override
+            public void onGiveup(Exception firstException, Exception lastException)
+            {
+                logger.warn("An error occurred while uploading a part {} / {}, give up on retries.", partNumber, totalParts, lastException);
+            }
+        }
+
+        private PartETag uploadPart(String key, File file, long fileOffset, long partSize, int partNumber, boolean isLastPart, String md5Digest)
+        {
+            return client.uploadPart(new UploadPartRequest()
+                    .withBucketName(bucket)
+                    .withKey(key)
+                    .withUploadId(multipartUploadId)
+                    .withFile(file)
+                    .withFileOffset(fileOffset)
+                    .withPartSize(partSize)
+                    .withPartNumber(partNumber)
+                    .withLastPart(isLastPart)
+                    .withMD5Digest(md5Digest))
+                    .getPartETag();
+        }
+
+        private void abortMultipartUploadIfNecessary(String key, ExecutorService executor)
+        {
+            if (multipartUploadId == null) { // Successfully completed
+                return;
+            }
+            try {
+                abortMultipartUpload(key, executor);
+                logger.info("Aborts a multipart upload. bucket '{}', key '{}', upload id '{}'", bucket, key, multipartUploadId);
+            }
+            catch (RuntimeException e) {
+                logger.warn("An error occurred while aborting a multipart upload.", e);
+                logger.warn("An incomplete multipart upload may remain. bucket '{}', key '{}', upload id '{}'", bucket, key, multipartUploadId);
+            }
+        }
+
+        private void abortMultipartUpload(String key, ExecutorService executor)
+        {
+            executor.shutdownNow(); // Attempts to terminate if possible
+            client.abortMultipartUpload(new AbortMultipartUploadRequest(bucket, key, multipartUploadId));
+        }
+
         private void putFile(Path from, String key)
         {
             PutObjectRequest request = new PutObjectRequest(bucket, key, from.toFile());
@@ -315,7 +487,7 @@ public class S3FileOutputPlugin
             }
 
             try {
-                putFile(tempFilePath, buildCurrentKey());
+                multipartUploadOrPutFile(tempFilePath, buildCurrentKey());
                 fileIndex++;
             }
             finally {
@@ -392,6 +564,87 @@ public class S3FileOutputPlugin
         {
             TaskReport report = CONFIG_MAPPER_FACTORY.newTaskReport();
             return report;
+        }
+
+        private static String md5AsBase64(File file, long fileOffset, long partSize)
+        {
+            try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+                raf.seek(fileOffset);
+                return Md5Utils.md5AsBase64(new FilePartInputStream(raf, partSize));
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static class FilePartInputStream extends FilterInputStream
+        {
+            final long partSize;
+            long partOffset;
+
+            FilePartInputStream(RandomAccessFile raf, long partSize)
+            {
+                super(Channels.newInputStream(raf.getChannel()));
+                this.partSize = partSize;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException
+            {
+                if (partOffset >= partSize) {
+                    return -1; // End of part reached
+                }
+                int bytesRead = super.read(b, off, (int) Math.min(len, partSize - partOffset));
+                if (bytesRead <= -1) {
+                    return -1; // End of file reached
+                }
+                partOffset += bytesRead;
+                return bytesRead;
+            }
+        }
+
+        private static <T> List<T> collect(List<Future<T>> futures)
+        {
+            return futures.stream().map(S3FileOutput::get).collect(Collectors.toList());
+        }
+
+        private static <T> T get(Future<T> future)
+        {
+            try {
+                return future.get();
+            }
+            catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class MultipartUpload
+    {
+        @JsonProperty("part_size")
+        public final long partSize;
+        @JsonProperty("max_threads")
+        public final int maxThreads;
+        @JsonProperty("retry_limit")
+        public final int retryLimit;
+
+        @JsonCreator
+        public MultipartUpload(@JsonProperty("part_size") String partSize, @JsonProperty("max_threads") Integer maxThreads, @JsonProperty("retry_limit") Integer retryLimit)
+        {
+            this.partSize = parseLong(partSize != null ? partSize : "5g");
+            this.maxThreads = maxThreads != null ? maxThreads : 4;
+            this.retryLimit = retryLimit != null ? retryLimit : 3;
+        }
+
+        private static final long K = 1024;
+        private static final long M = K * K;
+        private static final long G = M * K;
+
+        private static long parseLong(String valueWithUnit)
+        {
+            final long value = Long.parseLong(valueWithUnit.replaceFirst("[^0-9]*$", ""));
+            final String unit = valueWithUnit.replaceFirst("^[0-9]*", "").toLowerCase();
+            return value * (unit.equals("g") ? G : unit.equals("m") ? M : unit.equals("k") ? K : 1);
         }
     }
 


### PR DESCRIPTION
### PUT object (EntityTooLarge)

<details>
<summary>config.yml</summary>

```yml
exec:
  max_threads: 1
  min_output_tasks: 1
in:
  type: file
  path_prefix: test.10485760.jsonl.gz # 10G
  decoders:
  - {type: gzip}
  parser:
    type: jsonl
    columns:
    - {name: string, type: string}
out:
  type: s3
  auth_method: basic
  access_key_id: ***
  secret_access_key: ***
  region: ap-northeast-1
  bucket: trocco-sandbox
  path_prefix: test_by_sano/multipart_upload
  file_ext: .jsonl
  sequence_format: .%03d.%02d
  formatter:
    type: jsonl
```

</details>
<details>
<summary>embulk run</summary>

```
$ embulk run config.yml
2024-12-18 11:36:13.610 +0000: Embulk v0.9.26
2024-12-18 11:36:14.241 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-12-18 11:36:15.536 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-12-18 11:36:16.135 +0000 [INFO] (main): Started Embulk v0.9.26
2024-12-18 11:36:16.245 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-s3 (1.7.1.snapshot)
2024-12-18 11:36:16.277 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-12-18 11:36:16.286 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.10485760.jsonl.gz'
2024-12-18 11:36:16.287 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-12-18 11:36:16.290 +0000 [INFO] (0001:transaction): Loading files [test.10485760.jsonl.gz]
2024-12-18 11:36:16.307 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=1 / tasks=1
2024-12-18 11:36:16.336 +0000 [INFO] (0001:transaction): Loaded plugin embulk-formatter-jsonl (0.1.4)
2024-12-18 11:36:16.369 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-12-18 11:36:16.692 +0000 [INFO] (0015:task-0000): Writing S3 file 'test_by_sano/multipart_upload.000.00.jsonl'
2024-12-18 11:39:38.730 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
org.embulk.exec.PartialExecutionException: com.amazonaws.services.s3.model.AmazonS3Exception: Your proposed upload exceeds the maximum allowed size (Service: Amazon S3; Status Code: 400; Error Code: EntityTooLarge; Request ID: ****************; S3 Extended Request ID: ****************************************************************************; Proxy: null), S3 Extended Request ID: ****************************************************************************
	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:340)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:566)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:353)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:350)
	at org.embulk.spi.Exec.doWith(Exec.java:22)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:350)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:242)
	at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:290)
	at org.embulk.EmbulkRunner.run(EmbulkRunner.java:155)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:431)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
	at org.embulk.cli.Main.main(Main.java:64)
Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Your proposed upload exceeds the maximum allowed size (Service: Amazon S3; Status Code: 400; Error Code: EntityTooLarge; Request ID: ****************; S3 Extended Request ID: ****************************************************************************; Proxy: null), S3 Extended Request ID: ****************************************************************************
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(com/amazonaws/http/AmazonHttpClient.java:1819)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(com/amazonaws/http/AmazonHttpClient.java:1403)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(com/amazonaws/http/AmazonHttpClient.java:1372)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(com/amazonaws/http/AmazonHttpClient.java:1145)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(com/amazonaws/http/AmazonHttpClient.java:802)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(com/amazonaws/http/AmazonHttpClient.java:770)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(com/amazonaws/http/AmazonHttpClient.java:744)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(com/amazonaws/http/AmazonHttpClient.java:704)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(com/amazonaws/http/AmazonHttpClient.java:686)
	at com.amazonaws.http.AmazonHttpClient.execute(com/amazonaws/http/AmazonHttpClient.java:550)
	at com.amazonaws.http.AmazonHttpClient.execute(com/amazonaws/http/AmazonHttpClient.java:530)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(com/amazonaws/services/s3/AmazonS3Client.java:5437)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(com/amazonaws/services/s3/AmazonS3Client.java:5384)
	at com.amazonaws.services.s3.AmazonS3Client.access$300(com/amazonaws/services/s3/AmazonS3Client.java:421)
	at com.amazonaws.services.s3.AmazonS3Client$PutObjectStrategy.invokeServiceCall(com/amazonaws/services/s3/AmazonS3Client.java:6508)
	at com.amazonaws.services.s3.AmazonS3Client.uploadObject(com/amazonaws/services/s3/AmazonS3Client.java:1856)
	at com.amazonaws.services.s3.AmazonS3Client.putObject(com/amazonaws/services/s3/AmazonS3Client.java:1816)
	at org.embulk.output.s3.S3FileOutputPlugin$S3FileOutput.putFile(org/embulk/output/s3/S3FileOutputPlugin.java:534)
	at org.embulk.output.s3.S3FileOutputPlugin$S3FileOutput.multipartUploadOrPutFile(org/embulk/output/s3/S3FileOutputPlugin.java:341)
	at org.embulk.output.s3.S3FileOutputPlugin$S3FileOutput.closeCurrent(org/embulk/output/s3/S3FileOutputPlugin.java:544)
	at org.embulk.output.s3.S3FileOutputPlugin$S3FileOutput.finish(org/embulk/output/s3/S3FileOutputPlugin.java:601)
	at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
	at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:438)
	at org.jruby.javasupport.JavaMethod.invokeDirect(org/jruby/javasupport/JavaMethod.java:302)
	at RUBY.finish(uri:classloader:/gems/embulk-0.9.26-java/lib/embulk/file_output.rb:44)
	at RUBY.finish(/home/ubuntu/.embulk/lib/gems/gems/embulk-formatter-jsonl-0.1.4/lib/embulk/formatter/jsonl.rb:79)
	at RUBY.finish(uri:classloader:/gems/embulk-0.9.26-java/lib/embulk/formatter_plugin.rb:80)
	at Embulk$$FormatterPlugin$$JavaAdapter$$OutputAdapter_1623102721.finish(Embulk$$FormatterPlugin$$JavaAdapter$$OutputAdapter_1623102721.gen:13)
	at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.finish(org/embulk/spi/FileOutputRunner.java:154)
	at org.embulk.spi.PageBuilder.finish(org/embulk/spi/PageBuilder.java:227)
	at org.embulk.parser.jsonl.JsonlParserPlugin.run(org/embulk/parser/jsonl/JsonlParserPlugin.java:183)
	at org.embulk.spi.FileInputRunner.run(org/embulk/spi/FileInputRunner.java:140)
	at org.embulk.spi.util.Executors.process(org/embulk/spi/util/Executors.java:62)
	at org.embulk.spi.util.Executors.process(org/embulk/spi/util/Executors.java:38)
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(org/embulk/exec/LocalExecutorPlugin.java:170)
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(org/embulk/exec/LocalExecutorPlugin.java:167)
	at java.util.concurrent.FutureTask.run(java/util/concurrent/FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java/util/concurrent/ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java/util/concurrent/ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(java/lang/Thread.java:750)

Error: com.amazonaws.services.s3.model.AmazonS3Exception: Your proposed upload exceeds the maximum allowed size (Service: Amazon S3; Status Code: 400; Error Code: EntityTooLarge; Request ID: ****************; S3 Extended Request ID: ****************************************************************************; Proxy: null), S3 Extended Request ID: ****************************************************************************
```

</details>

### Multipart upload (part_size: 1g)

<details>
<summary>config.yml</summary>

```yml
out:
  ...
  multipart_upload:
    part_size: 1g
  ...
```

</details>
<details>
<summary>embulk run</summary>

```
$ embulk run config.yml
2024-12-18 11:41:17.271 +0000: Embulk v0.9.26
2024-12-18 11:41:17.886 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-12-18 11:41:19.217 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-12-18 11:41:19.860 +0000 [INFO] (main): Started Embulk v0.9.26
2024-12-18 11:41:19.933 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-s3 (1.7.1.snapshot)
2024-12-18 11:41:19.977 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-12-18 11:41:19.989 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.10485760.jsonl.gz'
2024-12-18 11:41:19.990 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-12-18 11:41:19.992 +0000 [INFO] (0001:transaction): Loading files [test.10485760.jsonl.gz]
2024-12-18 11:41:20.011 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=1 / tasks=1
2024-12-18 11:41:20.052 +0000 [INFO] (0001:transaction): Loaded plugin embulk-formatter-jsonl (0.1.4)
2024-12-18 11:41:20.092 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-12-18 11:41:20.372 +0000 [INFO] (0015:task-0000): Writing S3 file 'test_by_sano/multipart_upload.000.00.jsonl'
2024-12-18 11:44:32.534 +0000 [INFO] (pool-2-thread-1): Uploading a part 1 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:32.567 +0000 [INFO] (pool-2-thread-3): Uploading a part 3 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:32.639 +0000 [INFO] (pool-2-thread-2): Uploading a part 2 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:32.651 +0000 [INFO] (pool-2-thread-4): Uploading a part 4 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:39.219 +0000 [INFO] (pool-2-thread-4): Uploaded 4,294,967,296 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:39.369 +0000 [INFO] (pool-2-thread-1): Uploaded 1,073,741,824 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:39.403 +0000 [INFO] (pool-2-thread-2): Uploaded 2,147,483,648 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:39.730 +0000 [INFO] (pool-2-thread-3): Uploaded 3,221,225,472 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:41.961 +0000 [INFO] (pool-2-thread-4): Uploading a part 5 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:42.125 +0000 [INFO] (pool-2-thread-1): Uploading a part 6 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:42.162 +0000 [INFO] (pool-2-thread-2): Uploading a part 7 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:42.504 +0000 [INFO] (pool-2-thread-3): Uploading a part 8 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:48.731 +0000 [INFO] (pool-2-thread-4): Uploaded 5,368,709,120 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:48.749 +0000 [INFO] (pool-2-thread-2): Uploaded 7,516,192,768 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:49.154 +0000 [INFO] (pool-2-thread-3): Uploaded 8,589,934,592 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:49.426 +0000 [INFO] (pool-2-thread-1): Uploaded 6,442,450,944 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:51.488 +0000 [INFO] (pool-2-thread-4): Uploading a part 9 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:51.509 +0000 [INFO] (pool-2-thread-2): Uploading a part 10 / 10. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:44:58.181 +0000 [INFO] (pool-2-thread-4): Uploaded 9,663,676,416 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:58.247 +0000 [INFO] (pool-2-thread-2): Uploaded 10,737,418,240 / 10,737,418,240 bytes of the file. entity tag '37799b99cb0bd8573b64c278b987a86e'
2024-12-18 11:44:59.342 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-12-18 11:44:59.346 +0000 [INFO] (main): Committed.
2024-12-18 11:44:59.346 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.10485760.jsonl.gz"},"out":{}}
```

</details>

### Multipart upload (part_size: 5g)

<details>
<summary>config.yml</summary>

```yml
out:
  ...
  multipart_upload:
    part_size: 5g
  ...
```

</details>
<details>
<summary>embulk run</summary>

```
$ embulk run config.yml
2024-12-18 11:45:47.745 +0000: Embulk v0.9.26
2024-12-18 11:45:48.345 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-12-18 11:45:49.624 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-12-18 11:45:50.205 +0000 [INFO] (main): Started Embulk v0.9.26
2024-12-18 11:45:50.286 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-s3 (1.7.1.snapshot)
2024-12-18 11:45:50.319 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-12-18 11:45:50.329 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test.10485760.jsonl.gz'
2024-12-18 11:45:50.329 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-12-18 11:45:50.332 +0000 [INFO] (0001:transaction): Loading files [test.10485760.jsonl.gz]
2024-12-18 11:45:50.350 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=1 / tasks=1
2024-12-18 11:45:50.380 +0000 [INFO] (0001:transaction): Loaded plugin embulk-formatter-jsonl (0.1.4)
2024-12-18 11:45:50.416 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-12-18 11:45:50.748 +0000 [INFO] (0015:task-0000): Writing S3 file 'test_by_sano/multipart_upload.000.00.jsonl'
2024-12-18 11:49:11.284 +0000 [INFO] (pool-2-thread-1): Uploading a part 1 / 2. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:49:11.303 +0000 [INFO] (pool-2-thread-2): Uploading a part 2 / 2. bucket 'trocco-sandbox', key 'test_by_sano/multipart_upload.000.00.jsonl', upload id '********************************************************************************************************************************************************'
2024-12-18 11:49:43.895 +0000 [INFO] (pool-2-thread-1): Uploaded 5,368,709,120 / 10,737,418,240 bytes of the file. entity tag '9c15fe05ab201b4d665f9652b611040c'
2024-12-18 11:49:43.911 +0000 [INFO] (pool-2-thread-2): Uploaded 10,737,418,240 / 10,737,418,240 bytes of the file. entity tag '9c15fe05ab201b4d665f9652b611040c'
2024-12-18 11:49:45.008 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-12-18 11:49:45.012 +0000 [INFO] (main): Committed.
2024-12-18 11:49:45.013 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.10485760.jsonl.gz"},"out":{}}
```

</details>