### PR TITLE
replace to AwsCredentialsProviderV2 to meet AWS SDK v2

### DIFF
--- a/src/main/java/org/embulk/output/s3/AwsCredentialsProviderV2.java
+++ b/src/main/java/org/embulk/output/s3/AwsCredentialsProviderV2.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2015 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.output.s3;
+
+import org.embulk.config.ConfigException;
+import org.embulk.util.aws.credentials.AwsCredentialsTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+import java.nio.file.Paths;
+import java.util.Optional;
+
+/**
+ * A utility class to generate AWS SDK v2 AwsCredentialsProvider from Embulk's task-defining interface.
+ * This is compatible with embulk-util-aws-credentials but uses AWS SDK v2.
+ */
+public abstract class AwsCredentialsProviderV2
+{
+    private AwsCredentialsProviderV2()
+    {
+        // No instantiation.
+    }
+
+    /**
+     * Creates AWS SDK v2 AwsCredentialsProvider from entries in task definition.
+     *
+     * @param task An entry in Embulk's task defining interface
+     * @return AwsCredentialsProvider created
+     */
+    public static AwsCredentialsProvider getAwsCredentialsProvider(AwsCredentialsTask task)
+    {
+        return getAwsCredentialsProvider("", task);
+    }
+
+    private static AwsCredentialsProvider getAwsCredentialsProvider(String prefix, AwsCredentialsTask task)
+    {
+        String authMethodOption = prefix + "auth_method";
+        String sessionTokenOption = prefix + "session_token";
+        String profileFileOption = prefix + "profile_file";
+        String profileNameOption = prefix + "profile_name";
+        String accessKeyIdOption = prefix + "access_key_id";
+        String secretAccessKeyOption = prefix + "secret_access_key";
+        String accountIdOption = prefix + "account_id";
+        String roleNameOption = prefix + "role_name";
+        String externalIdOption = prefix + "external_id";
+
+        switch (task.getAuthMethod()) {
+            case "basic":
+                // for backward compatibility
+                if (!task.getAccessKeyId().isPresent() && !task.getSecretAccessKey().isPresent()) {
+                    log.warn("Both '{}' and '{}' are not set. Assuming that '{}: anonymous' option is set.",
+                            accessKeyIdOption, secretAccessKeyOption, authMethodOption);
+                    log.warn("If you intentionally use anonymous authentication, please set 'auth_method: anonymous' option.");
+                    log.warn("This behavior will be removed in a future release.");
+                    reject(task.getSessionToken(), sessionTokenOption);
+                    reject(task.getProfileFile(), profileFileOption);
+                    reject(task.getProfileName(), profileNameOption);
+                    reject(task.getAccountId(), accountIdOption);
+                    reject(task.getRoleName(), roleNameOption);
+                    reject(task.getExternalId(), externalIdOption);
+                    return AnonymousCredentialsProvider.create();
+                }
+                else {
+                    reject(task.getSessionToken(), sessionTokenOption);
+                    reject(task.getProfileFile(), profileFileOption);
+                    reject(task.getProfileName(), profileNameOption);
+                    reject(task.getExternalId(), externalIdOption);
+                    reject(task.getAccountId(), accountIdOption);
+                    reject(task.getRoleName(), roleNameOption);
+                    final String accessKeyId = require(task.getAccessKeyId(), "'access_key_id', 'secret_access_key'");
+                    final String secretAccessKey = require(task.getSecretAccessKey(), "'secret_access_key'");
+                    return StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+                    );
+                }
+
+            case "env":
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
+                reject(task.getAccountId(), accountIdOption);
+                reject(task.getRoleName(), roleNameOption);
+                reject(task.getExternalId(), externalIdOption);
+                return EnvironmentVariableCredentialsProvider.create();
+
+            case "instance":
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
+                reject(task.getAccountId(), accountIdOption);
+                reject(task.getRoleName(), roleNameOption);
+                reject(task.getExternalId(), externalIdOption);
+                return InstanceProfileCredentialsProvider.create();
+
+            case "profile":
+            {
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getAccountId(), accountIdOption);
+                reject(task.getRoleName(), roleNameOption);
+                reject(task.getExternalId(), externalIdOption);
+
+                String profileName = task.getProfileName().orElse("default");
+                ProfileCredentialsProvider.Builder builder = ProfileCredentialsProvider.builder()
+                        .profileName(profileName);
+
+                if (task.getProfileFile().isPresent()) {
+                    builder.profileFile(ProfileFile.builder()
+                            .content(Paths.get(task.getProfileFile().get()))
+                            .type(ProfileFile.Type.CREDENTIALS)
+                            .build());
+                }
+
+                return builder.build();
+            }
+
+            case "properties":
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
+                reject(task.getAccountId(), accountIdOption);
+                reject(task.getRoleName(), roleNameOption);
+                reject(task.getExternalId(), externalIdOption);
+                return SystemPropertyCredentialsProvider.create();
+
+            case "anonymous":
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
+                reject(task.getAccountId(), accountIdOption);
+                reject(task.getRoleName(), roleNameOption);
+                reject(task.getExternalId(), externalIdOption);
+                return AnonymousCredentialsProvider.create();
+
+            case "session":
+            {
+                final String accessKeyId = require(task.getAccessKeyId(),
+                        "'" + accessKeyIdOption + "', '" + secretAccessKeyOption + "', '" + sessionTokenOption + "'");
+                final String secretAccessKey = require(task.getSecretAccessKey(),
+                        "'" + secretAccessKeyOption + "', '" + sessionTokenOption + "'");
+                final String sessionToken = require(task.getSessionToken(),
+                        "'" + sessionTokenOption + "'");
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
+                reject(task.getAccountId(), accountIdOption);
+                reject(task.getRoleName(), roleNameOption);
+                reject(task.getExternalId(), externalIdOption);
+                return StaticCredentialsProvider.create(
+                        AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken)
+                );
+            }
+
+            case "assume_role":
+            {
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
+                final String accountId = require(task.getAccountId(),
+                        "'" + accountIdOption + "'");
+                final String roleName = require(task.getRoleName(),
+                        "'" + roleNameOption + "'");
+                final String externalId = require(task.getExternalId(),
+                        "'" + externalIdOption + "'");
+                final String arn = String.format(ARN_PATTERN, task.getArnPartition(), accountId, roleName);
+
+                // Create STS client with default credentials provider chain
+                StsClient stsClient = StsClient.builder()
+                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .build();
+
+                AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
+                        .roleArn(arn)
+                        .roleSessionName(task.getSessionName())
+                        .externalId(externalId)
+                        .durationSeconds(task.getDurationInSeconds())
+                        .build();
+
+                return StsAssumeRoleCredentialsProvider.builder()
+                        .stsClient(stsClient)
+                        .refreshRequest(assumeRoleRequest)
+                        .asyncCredentialUpdateEnabled(false)
+                        .build();
+            }
+
+            case "default":
+            {
+                reject(task.getAccessKeyId(), accessKeyIdOption);
+                reject(task.getSecretAccessKey(), secretAccessKeyOption);
+                reject(task.getSessionToken(), sessionTokenOption);
+                reject(task.getProfileFile(), profileFileOption);
+                reject(task.getProfileName(), profileNameOption);
+                reject(task.getAccountId(), accountIdOption);
+                reject(task.getRoleName(), roleNameOption);
+                reject(task.getExternalId(), externalIdOption);
+                return DefaultCredentialsProvider.create();
+            }
+
+            default:
+                throw new ConfigException(String.format("Unknown auth_method '%s'. Supported methods are basic, env, instance, profile, properties, anonymous, session, assume_role and default.",
+                        task.getAuthMethod()));
+        }
+    }
+
+    private static <T> T require(Optional<T> value, String message)
+    {
+        if (value.isPresent()) {
+            return value.get();
+        }
+        else {
+            throw new ConfigException("Required option is not set: " + message);
+        }
+    }
+
+    private static <T> void reject(Optional<T> value, String message)
+    {
+        if (value.isPresent()) {
+            throw new ConfigException("Invalid option is set: " + message);
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(AwsCredentialsProviderV2.class);
+    private static final String ARN_PATTERN = "arn:%s:iam::%s:role/%s";
+}

--- a/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/s3/S3FileOutputPlugin.java
@@ -33,8 +33,6 @@ import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Locale;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -66,7 +64,6 @@ import org.embulk.util.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Buffer;
-import org.embulk.spi.Exec;
 import org.embulk.spi.FileOutput;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.TransactionalFileOutput;
@@ -179,26 +176,13 @@ public class S3FileOutputPlugin
                     .credentialsProvider(getCredentialsProvider(task))
                     .httpClientBuilder(getHttpClientBuilder(task));
 
-            // Favor the `endpoint` configuration, then `region`, if both are absent then use default region provider
-            if (endpoint.isPresent()) {
-                if (region.isPresent()) {
-                    logger.warn("Either configure endpoint or region, " +
-                            "if both is specified only the endpoint will be in effect.");
-                }
-                builder.endpointOverride(URI.create(endpoint.get()));
-                // When endpoint is specified, still need a region but it will use the endpoint
-                if (region.isPresent()) {
-                    builder.region(Region.of(region.get()));
-                }
-                else {
-                    builder.region(Region.US_EAST_1);
-                }
-            }
-            else if (region.isPresent()) {
+            if (region.isPresent()) {
                 builder.region(Region.of(region.get()));
             }
-            // If neither endpoint nor region is specified, don't set region explicitly
-            // This allows the SDK to use the default region provider chain
+
+            if (endpoint.isPresent()) {
+                builder.endpointOverride(URI.create(endpoint.get()));
+            }
 
             builder.forcePathStyle(false);
             return builder.build();
@@ -206,20 +190,7 @@ public class S3FileOutputPlugin
 
         private AwsCredentialsProvider getCredentialsProvider(PluginTask task)
         {
-            // Convert AWS SDK v1 credentials provider to v2
-            AWSCredentialsProvider v1Provider = org.embulk.util.aws.credentials.AwsCredentials.getAWSCredentialsProvider(task);
-            return new AwsCredentialsProvider()
-            {
-                @Override
-                public software.amazon.awssdk.auth.credentials.AwsCredentials resolveCredentials()
-                {
-                    com.amazonaws.auth.AWSCredentials v1Creds = v1Provider.getCredentials();
-                    return AwsBasicCredentials.create(
-                        v1Creds.getAWSAccessKeyId(),
-                        v1Creds.getAWSSecretKey()
-                    );
-                }
-            };
+            return AwsCredentialsProviderV2.getAwsCredentialsProvider(task);
         }
 
         private ApacheHttpClient.Builder getHttpClientBuilder(PluginTask task)


### PR DESCRIPTION
AWS SDK v2対応時に claude が置き換えミスったのを見逃していました
https://github.com/trocco-io/embulk-output-s3/pull/5/files#diff-5bf344a9e0a24f508610f1687a509655835efe179cc662f76985bac34686335eL210

https://github.com/embulk/embulk-util-aws-credentials
をコピーしてv2に対応